### PR TITLE
standard drag space

### DIFF
--- a/src/lib/ElegantKnob.svelte
+++ b/src/lib/ElegantKnob.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
- import knobdrag, { makeValueStore } from '$lib/knobdrag';
- import Input from '$lib/Input.svelte';
+ import knobdrag, { makeValueStore } from './knobdrag';
+ import Input from './Input.svelte';
 
  // Parameters
  export let min = 0;
  export let max = 100;
  export let step = (max - min) / 100;
+ export let space = 700;
  export let value = (min + max) / 2;
  const valueStore = makeValueStore(value, newValue => value = newValue);
  $: valueStore.set(value);
  let inputElem: Element;
- $: knobParams = { min, max, step, valueStore, inputElem };
+ $: knobParams = { min, max, step, space, valueStore, inputElem };
 
  // Aesthetic
  export let size = '5rem';

--- a/src/lib/MinimalKnob.svelte
+++ b/src/lib/MinimalKnob.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
- import knobdrag, {makeValueStore} from '$lib/knobdrag.js';
- import Input from '$lib/Input.svelte';
+ import knobdrag, {makeValueStore} from './knobdrag.js';
+ import Input from './Input.svelte';
 
  // Parameters
  export let min = 0;
  export let max = 100;
  export let step = (max - min) / 100;
+ export let space = 700;
  export let value = (min + max) / 2;
  const valueStore = makeValueStore(value, newValue => value = newValue);
  $: valueStore.set(value);
  let inputElem: Element;
- $: knobParams = { min, max, step, valueStore, inputElem };
+ $: knobParams = { min, max, step, space, valueStore, inputElem };
 
  // Aesthetic
  export let size = '5rem';

--- a/src/lib/knobdrag.ts
+++ b/src/lib/knobdrag.ts
@@ -6,6 +6,7 @@ interface Params {
     min: number,
     max: number,
     step: number,
+    space: number,
     valueStore: Writable<number>,
     inputElem: HTMLInputElement,
 }
@@ -30,7 +31,7 @@ export default function knobdrag(elem: HTMLElement, params: Params) {
     // fit our range onto a standard drag-distance space
     //  700px seems good can be done in either direction by a relaxed hand
     let range = params.max - params.min
-    let scaleFactor = 700 / range
+    let scaleFactor = params.space / range
     function scaleMovement(distance:number) {
         return distance /= scaleFactor
     }

--- a/src/lib/knobdrag.ts
+++ b/src/lib/knobdrag.ts
@@ -26,6 +26,15 @@ export default function knobdrag(elem: HTMLElement, params: Params) {
             actions.delete('pointerlock');
         }
     });
+
+    // fit our range onto a standard drag-distance space
+    //  700px seems good can be done in either direction by a relaxed hand
+    let range = params.max - params.min
+    let scaleFactor = 700 / range
+    function scaleMovement(distance:number) {
+        return distance /= scaleFactor
+    }
+
     let moved = false;
     function knobMove(event: PointerEvent): void {
         const { movementY, pointerId } = event;
@@ -34,7 +43,7 @@ export default function knobdrag(elem: HTMLElement, params: Params) {
                 moved = true;
                 return clamp(
                     params.min,
-                    value - (movementY * params.step),
+                    value - (scaleMovement(movementY) * params.step),
                     params.max
                 );
             });


### PR DESCRIPTION
The maths for converting gesture to value was too simple.
It's good for min=0,max=100, but
-   max=5 is hard to select a mid-range value
-   max=5000 is a couple of A4 mousepads away

Now the drag space is set to 700px.
That might be high so I made a space param.



Questions and suggestions:

How do you do this? I've never hacked on a node module before. I changed my code to use my fork:
`import ElegantKnob from '$lib/ui/svelte-dj-knob/src/lib/ElegantKnob.svelte'`
in ElegantKnob.svelte, I adjusted these imports to not use $lib which becomes for the outer svelte project.

pointerlock() looks confusing, esp. the options.ts part.
It doesn't work for me:
-   the top of my screen stops me dragging up
-   my cursor uncloaks away from where it started.

Debouncing the output value.
I sometimes getting 100 callbacks per second while twiddling.
I believe this is why I experience [the demo](https://svelte-dj-knob.netlify.app/) sticking on one colour for a while when I twiddle too much: because the fast callbacks trip the browser into throttling us more severely than a debounce to 24fps or so.
Not sure, I'm not hugely Frontended.

What's the latest in UI widgetry?