### PR TITLE
Update MinimalKnob.svelte

### DIFF
--- a/src/lib/MinimalKnob.svelte
+++ b/src/lib/MinimalKnob.svelte
@@ -17,6 +17,7 @@
  export let strokeWidth = 8;
  export let bgColor = '#fff';
  export let valueColor = '#7f9fff';
+ export let textColor = '#fff'
  export let label: string | undefined = undefined;
 
 </script>
@@ -41,7 +42,7 @@
                 <Input
                     bind:value
                     bind:inputElem
-                    color="{bgColor}"
+                    color="{textColor}"
                 />
             </div>
         </foreignObject>


### PR DESCRIPTION
added new `textColor` prop to MinimalKnob, and passed it to MinimalKnob's Input component via `color` prop. This allows for the number value, the background svg, and the fill color svgs to all be different colors if desired.
![Screenshot 2024-09-18 at 12 12 39 PM](https://github.com/user-attachments/assets/fde253cb-e295-4a00-9591-7c4f0a87880f)
